### PR TITLE
add create_bracket_order()

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Once you've obtained the key and secret you can authenticate manually with
 
 ```julia
 using AlpacaMarkets
-AlpacaMarkets.select_account("PAPER")
+AlpacaMarkets.trading_env("PAPER")
 AlpacaMarkets.auth(KEY, SECRET)
 ```
 
@@ -49,13 +49,12 @@ So you can pull some historical data as and when needed.
 
 Trading API functions are available up to account, orders and positions:
 
-* `account`, `get_orders`, `place_order`, `place_market_order`
-* `place_limit_order`, `place_stop_order`, `place_stop_limit_order`,
-* `place_trailing_stop_order`, `place_bracket_order`,
-* `place_oco_order`, `place_oto_order`, `replace_an_order`, 
-* `cancel_order`, `cancel_all_orders`, `get_orders_by_order_id`
-* `get_orders_by_client_order_id`, `get_open_positions`, 
-* `get_position`, `close_all_positions`, `close_position`
+* `account`, `create_market_order`, `create_limit_order`, `create_stop_order`
+* `create_stop_limit_order`, `create_trailing_stop_order`, `create_bracket_order`,
+* `get_orders`, `get_orders_by_order_id`, `get_orders_by_client_order_id`,
+* `cancel_all_orders`, `cancel_order`, `replace_an_order`, 
+* `close_all_positions`, `close_position`, `get_all_positions`
+* `get_position`
 
 ## To Do
 

--- a/src/orders.jl
+++ b/src/orders.jl
@@ -1,4 +1,4 @@
-function create_order_params(;symbol, side, qty=NaN, notional=NaN, time_in_force, type, extended_hours=false, client_order_id="none", order_class=nothing)
+function create_order_params(;symbol, side, qty=NaN, notional=NaN, time_in_force, type, extended_hours=false, client_order_id="none", tp_limit_price=nothing, sl_stop_price=nothing, sl_limit_price=nothing,order_class=nothing)
 
   validate_order(side, time_in_force, qty, notional, order_class, type)
 
@@ -84,7 +84,8 @@ function create_trailing_stop_order(;symbol, side, qty=NaN, notional=NaN, trail_
 end
 
 function create_bracket_order(;symbol, side, type, qty=NaN, notional=NaN, limit_price=NaN, stop_price=NaN, tp_limit_price, sl_stop_price, sl_limit_price, time_in_force, extended_hours=false, client_order_id="none")
-  params = create_order_params(symbol=symbol, side=side, qty=qty, notional=notional, time_in_force = time_in_force, type = type, extended_hours=extended_hours, client_order_id=client_order_id, order_class="bracket")
+  params = create_order_params(symbol=symbol, side=side, qty=qty, notional=notional, time_in_force = time_in_force, type = type, extended_hours=extended_hours, tp_limit_price=tp_limit_price, sl_stop_price=sl_stop_price, 
+  sl_limit_price=sl_limit_price, client_order_id=client_order_id, order_class="bracket")
 
   if !isnan(limit_price)
     params["limit_price"] = limit_price

--- a/src/positions.jl
+++ b/src/positions.jl
@@ -27,16 +27,7 @@ function close_position(symbol::String; qty=NaN, percentage=NaN)::DataFrame
   return resdf
 end
 
-function get_position(symbol::String)::DataFrame
-  url = join([TRADING_API_URL, "positions", symbol], "/")
-
-  res = HTTP.get(url, headers = HEADERS[])
-  resdict = JSON.parse(String(res.body))
-  resdf = DataFrame(resdict)
-  return resdf
-end
-
-function get_all_positions()::DataFrame
+function get_positions()::DataFrame
   url = join([TRADING_API_URL, "positions"], "/")
 
   res = HTTP.get(url, headers = HEADERS[])

--- a/src/positions.jl
+++ b/src/positions.jl
@@ -27,7 +27,7 @@ function close_position(symbol::String; qty=NaN, percentage=NaN)::DataFrame
   return resdf
 end
 
-function get_positions(symbol::String)::DataFrame
+function get_position(symbol::String)::DataFrame
   url = join([TRADING_API_URL, "positions", symbol], "/")
 
   res = HTTP.get(url, headers = HEADERS[])
@@ -36,7 +36,7 @@ function get_positions(symbol::String)::DataFrame
   return resdf
 end
 
-function get_positions()::DataFrame
+function get_all_positions()::DataFrame
   url = join([TRADING_API_URL, "positions"], "/")
 
   res = HTTP.get(url, headers = HEADERS[])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -95,16 +95,29 @@ function validate_side(side::String)
 end
 
 function validate_size(qty, notional)
-  @assert sum(isnan.([qty, notional])) == 1
+  @assert sum(isnan.([qty, notional])) == 1 "Either qty or notational - can not state both"
   true
 end
 
+function validate_type(type::String)
+  @assert type in ["market", "limit", "stop", "stop_limit", "trailing_stop"] "valid types :: market, limit, stop, stop_limit, or trailing_stop"
+  true
+end
 
-function validate_order(side::String, tif::String, qty, notional)
+function validate_class(order_class::Any)
+  if isnothing(order_class)
+    order_class = "simple"
+  end
+  @assert order_class in ["simple", "bracket", "oco ", "oto"] "valid order class :: simple, bracket, oco, oto"
+  true
+end
+
+function validate_order(side::String, tif::String, qty, notional, order_class, type::String)
   validate_side(side)
   validate_tif(tif)
   validate_size(qty, notional)
+  validate_type(type)
+  validate_class(order_class)
   true
 end
-
 

--- a/test/orders_test.jl
+++ b/test/orders_test.jl
@@ -12,7 +12,7 @@
     @test params["notional"] == 100
     #@test !(["qty", "client_order_id"] in keys(params))
 
-    params = create_order_params(symbol="AAPL", side = "buy", qty = 1, time_in_force = "ioc", type = "market", order_class = "bracket")
+    params = AlpacaMarkets.create_order_params(symbol="AAPL", side = "buy", qty = 1, time_in_force = "ioc", type = "market", order_class = "bracket")
 
     @test params["order_class"] == "bracket"
   

--- a/test/orders_test.jl
+++ b/test/orders_test.jl
@@ -11,8 +11,11 @@
 
     @test params["notional"] == 100
     #@test !(["qty", "client_order_id"] in keys(params))
-    
 
+    params = create_order_params(symbol="AAPL", side = "buy", qty = 1, time_in_force = "ioc", type = "market", order_class = "bracket")
+
+    @test params["order_class"] == "bracket"
+  
   end 
 
 end

--- a/test/orders_test.jl
+++ b/test/orders_test.jl
@@ -12,10 +12,10 @@
     @test params["notional"] == 100
     #@test !(["qty", "client_order_id"] in keys(params))
 
-    params = AlpacaMarkets.create_order_params(symbol="AAPL", side = "buy", qty = 1, time_in_force = "ioc", type = "market", order_class = "bracket")
+    params = AlpacaMarkets.create_order_params(symbol="AAPL", side = "buy", qty = 1, time_in_force = "day", type = "market", tp_limit_price=196.10, sl_stop_price=194.00, sl_limit_price = 193.60, order_class = "bracket")
 
     @test params["order_class"] == "bracket"
-  
+
   end 
 
 end


### PR DESCRIPTION
extend existing ```create_order_params()``` to include ```simple, bracket, oco or oto``` orders. note embedded ```Dict()``` within ```Dict()``` within JSON body for the extra price fields.